### PR TITLE
Add concurrency settings to workflows

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,6 +5,10 @@ on:
       - master
   workflow_dispatch:
 
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   deploy:
     name: Build and Deployment to Production

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,10 @@
 name: Pull Request
 on:
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   test:
     name: Test


### PR DESCRIPTION
## Overview

Added concurrency settings to GitHub workflow files to prevent multiple workflow runs from running simultaneously for the same branch/PR, following the pattern established in the Nexus repository.

## Changes Made

### Workflow Concurrency Updates
- **Updated:**
  - `.github/workflows/production.yml`: Added concurrency settings for production deployments
  - `.github/workflows/pull-request.yml`: Added concurrency settings for PR workflows

### Concurrency Configuration
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Benefits
1. **Resource Optimization:** Prevents multiple workflows from running simultaneously for the same branch
2. **Faster Feedback:** Cancels outdated workflow runs when new commits are pushed  
3. **Cost Reduction:** Reduces unnecessary compute usage in CI/CD
4. **Cleaner UI:** Fewer redundant workflow runs in GitHub Actions interface