### PR TITLE
[PN-3431] feat: add OpenCerts v2.2 schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10535,6 +10535,161 @@
         "follow-redirects": "^1.10.0"
       }
     },
+    "node_modules/babel-code-frame": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+      "integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-code-frame/node_modules/js-tokens": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+      "integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/babel-code-frame/node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/babel-core": {
+      "version": "6.26.3",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+      "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-generator": "^6.26.0",
+        "babel-helpers": "^6.24.1",
+        "babel-messages": "^6.23.0",
+        "babel-register": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "babel-template": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "convert-source-map": "^1.5.1",
+        "debug": "^2.6.9",
+        "json5": "^0.5.1",
+        "lodash": "^4.17.4",
+        "minimatch": "^3.0.4",
+        "path-is-absolute": "^1.0.1",
+        "private": "^0.1.8",
+        "slash": "^1.0.0",
+        "source-map": "^0.5.7"
+      }
+    },
+    "node_modules/babel-core/node_modules/json5": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "integrity": "sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/babel-core/node_modules/slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-generator": {
+      "version": "6.26.1",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
+      "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "detect-indent": "^4.0.0",
+        "jsesc": "^1.3.0",
+        "lodash": "^4.17.4",
+        "source-map": "^0.5.7",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "node_modules/babel-generator/node_modules/detect-indent": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+      "integrity": "sha512-BDKtmHlOzwI7iRuEkhzsnPoi5ypEhWAJB5RvHWe1kMr06js3uK5B3734i3ui5Yd+wOJV1cpE4JnivPD283GU/A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "repeating": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-generator/node_modules/jsesc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "integrity": "sha512-Mke0DA0QjUWuJlhsE0ZPPhYiJkRap642SmI/4ztCFaUs6V2AiH1sfecc+57NgaryfAA2VR3v6O+CSjC1jZJKOA==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "jsesc": "bin/jsesc"
+      }
+    },
+    "node_modules/babel-helpers": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
+      "integrity": "sha512-n7pFrqQm44TCYvrCDb0MqabAF+JUBq+ijBvNMUxpkLjJaAu32faIexewMumrH5KLLJ1HDyT0PTEqRyAe/GwwuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0",
+        "babel-template": "^6.24.1"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.0.6.tgz",
@@ -10864,6 +11019,16 @@
         "typedarray-to-buffer": "^3.1.5"
       }
     },
+    "node_modules/babel-messages": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-runtime": "^6.22.0"
+      }
+    },
     "node_modules/babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
@@ -11004,6 +11169,118 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/babel-register": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
+      "integrity": "sha512-veliHlHX06wjaeY8xNITbveXSiI+ASFnOqvne/LaIJIqOWi2Ogmj91KOugEz/hoh/fwMhXNBJPCv8Xaz5CyM4A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-core": "^6.26.0",
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "home-or-tmp": "^2.0.0",
+        "lodash": "^4.17.4",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.4.15"
+      }
+    },
+    "node_modules/babel-register/node_modules/source-map-support": {
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "source-map": "^0.5.6"
+      }
+    },
+    "node_modules/babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      }
+    },
+    "node_modules/babel-template": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "integrity": "sha512-PCOcLFW7/eazGUKIoqH97sO9A2UYMahsn/yRQ7uOk37iutwjq7ODtcTNF+iFDSHNfkctqsLRjLP7URnOx0T1fg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "babel-traverse": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-code-frame": "^6.26.0",
+        "babel-messages": "^6.23.0",
+        "babel-runtime": "^6.26.0",
+        "babel-types": "^6.26.0",
+        "babylon": "^6.18.0",
+        "debug": "^2.6.8",
+        "globals": "^9.18.0",
+        "invariant": "^2.2.2",
+        "lodash": "^4.17.4"
+      }
+    },
+    "node_modules/babel-traverse/node_modules/globals": {
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babel-types": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "integrity": "sha512-zhe3V/26rCWsEZK8kZN+HaQj5yQ1CilTObixFzKW1UWjqG7618Twz6YEsCnjfg5gBcJh02DrpCkS9h98ZqDY+g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "babel-runtime": "^6.26.0",
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.4",
+        "to-fast-properties": "^1.0.3"
+      }
+    },
+    "node_modules/babel-types/node_modules/to-fast-properties": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "integrity": "sha512-lxrWP8ejsq+7E3nNjwYmUBMAgjMTZoTI+sdBOpvNyijeDLa29LUn9QaoXAHv4+Z578hbmHHJKZknzxVtvo77og==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/babylon": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "babylon": "bin/babylon.js"
       }
     },
     "node_modules/balanced-match": {
@@ -11958,6 +12235,15 @@
       "dependencies": {
         "safe-buffer": "~5.1.1"
       }
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true
     },
     "node_modules/core-js-compat": {
       "version": "3.16.0",
@@ -15085,6 +15371,20 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==",
       "dev": true
     },
+    "node_modules/home-or-tmp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+      "integrity": "sha512-ycURW7oUxE2sNiPVw1HVEFsW+ecOpJ5zaj7eC0RlwhibhRBod20muUN8qu/gzx956YrLolVvs1MTXwKgC2rVEg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -15575,6 +15875,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/ip": {
@@ -20575,6 +20885,19 @@
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
@@ -24596,6 +24919,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/private": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -24989,6 +25322,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/regenerator-transform": {
       "version": "0.14.5",
@@ -26905,6 +27245,16 @@
       "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
       "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
       "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha512-WZGXGstmCWgeevgTL54hrCuw1dyMQIzWy7ZfqRJfSmJZBwklI15egmQytFP6bPidmw3M8d5yEowl1niq4vmqZw==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }

--- a/schema/transcripts/2.2/changelog
+++ b/schema/transcripts/2.2/changelog
@@ -1,0 +1,6 @@
+changelog
+
+Added new optional network field as an object for use with DNS-TXT Blockchain issued certificates with fields:
+- chain => mandatory string
+- chainId => mandatory string
+Taken from (https://github.com/Open-Attestation/open-attestation/blob/master/src/2.0/schema/schema.json)

--- a/schema/transcripts/2.2/example-did-document.json
+++ b/schema/transcripts/2.2/example-did-document.json
@@ -1,0 +1,137 @@
+{
+  "id": "SERIAL-2018-08-01-112",
+  "$template": {
+    "name": "CUSTOM_TEMPLATE",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://demo-renderer.opencerts.io"
+  },
+  "description": "This masters is awarded to developers who can blockchain",
+  "issuedOn": "2018-08-01T00:00:00+08:00",
+  "expiresOn": "2118-08-01T00:00:00+08:00",
+  "name": "Master of Blockchain",
+  "admissionDate": "2017-07-01T00:00:00+08:00",
+  "graduationDate": "2018-08-01T00:00:00+08:00",
+  "attainmentDate": "2018-07-25T00:00:00+08:00",
+  "issuers": [
+    {
+      "name": "Blockchain Academy",
+      "did": "DID:SG-UEN:U18274928E",
+      "url": "https://blockchainacademy.com",
+      "email": "registrar@blockchainacademy.com",
+      "documentStore": "0xd9580260be45c3c0c2fb259a82f219b513054012",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      },
+      "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "name": "School of Crypto-economics",
+      "url": "https://ceschool.sg",
+      "documentStore": "0xA33ddAEE02369D18A21E29dD2E7A12d65eE671d2",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      }
+    },
+    {
+      "id": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      "name": "DEMO STORE",
+      "revocation": { "type": "NONE" },
+      "identityProof": {
+        "type": "DID",
+        "key": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller"
+      }
+    }
+  ],
+  "recipient": {
+    "name": "Mr Blockchain",
+    "did": "DID:SG-NRIC:S99999999A",
+    "email": "mr-blockchain@gmail.com",
+    "phone": "+65 88888888",
+    "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nric": "S0000001Z",
+    "fin": "F0000001Z",
+    "studentId": "1232"
+  },
+  "qualificationLevel": [
+    {
+      "frameworkName": "singapore/ssec-eqa",
+      "frameworkVersion": "2015",
+      "code": "51",
+      "description": "Polytechnic Diploma"
+    },
+    {
+      "frameworkName": "international/isced",
+      "frameworkVersion": "2011",
+      "code": "55",
+      "description": "(Short-cycle tertiary education) Vocational"
+    }
+  ],
+  "fieldOfStudy": [
+    {
+      "frameworkName": "singapore/ssec-fos",
+      "frameworkVersion": "2015",
+      "code": "0897",
+      "description": "Biomedical Science"
+    }
+  ],
+  "transcript": [
+    {
+      "name": "Bitcoin",
+      "grade": "A+",
+      "courseCredit": 3,
+      "courseCode": "BTC-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/BTC-01",
+      "description": "Everything and more about bitcoin!"
+    },
+    {
+      "name": "Ethereum",
+      "grade": "A+",
+      "courseCredit": "3.5",
+      "courseCode": "ETH-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/ETH-01",
+      "description": "Everything and more about ethereum!"
+    }
+  ],
+  "cumulativeScore": 3.9935,
+  "additionalData": {
+    "coCurricularActivities": [
+      {
+        "name": "Crypto-investment Club",
+        "position": "Club President",
+        "startDate": "2017-08-01T00:00:00+08:00",
+        "endDate": "2018-08-01T00:00:00+08:00",
+        "remarks": "Top trader (2018)"
+      }
+    ],
+    "npfa": "silver",
+    "images": {
+      "signature1": {
+        "name": "Mr Important",
+        "designation": "President",
+        "signature": "<-- Base64 Image -->"
+      },
+      "signature2": {
+        "name": "Mr Not-So-Important",
+        "designation": "Chairman, Blockchain Faculty",
+        "signature": "<-- Base64 Image -->"
+      }
+    }
+  },
+  "skills": [
+    {
+      "frameworkUri": "https://www.skillsfuture.sg/skills-framework",
+      "frameworkVersion": "1.0",
+      "frameworkName": "SFw",
+      "sector": "Air Transport",
+      "category": "Aircraft Operations",
+      "competencyCode": "ATP-ACO-4001-1.1",
+      "competencyDescription": "Monitor aircraft systems, performance and external environments as well as comply with Air Traffic Control (ATC) instructions and en route navigation requirements to ensure safe and optimal flight conditions",
+      "competencyLevel": "Level 4",
+      "competencyLevelDescription": "Analyse aircraft performance through close monitoring of flight decks to ensure optimal flight conditions during cruise"
+    }
+  ]
+}

--- a/schema/transcripts/2.2/example-dns-did-document.json
+++ b/schema/transcripts/2.2/example-dns-did-document.json
@@ -1,0 +1,138 @@
+{
+  "id": "SERIAL-2018-08-01-112",
+  "$template": {
+    "name": "CUSTOM_TEMPLATE",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://demo-renderer.opencerts.io"
+  },
+  "description": "This masters is awarded to developers who can blockchain",
+  "issuedOn": "2018-08-01T00:00:00+08:00",
+  "expiresOn": "2118-08-01T00:00:00+08:00",
+  "name": "Master of Blockchain",
+  "admissionDate": "2017-07-01T00:00:00+08:00",
+  "graduationDate": "2018-08-01T00:00:00+08:00",
+  "attainmentDate": "2018-07-25T00:00:00+08:00",
+  "issuers": [
+    {
+      "name": "Blockchain Academy",
+      "did": "DID:SG-UEN:U18274928E",
+      "url": "https://blockchainacademy.com",
+      "email": "registrar@blockchainacademy.com",
+      "documentStore": "0xd9580260be45c3c0c2fb259a82f219b513054012",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      },
+      "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "name": "School of Crypto-economics",
+      "url": "https://ceschool.sg",
+      "documentStore": "0xA33ddAEE02369D18A21E29dD2E7A12d65eE671d2",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      }
+    },
+    {
+      "id": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+      "name": "DEMO STORE",
+      "revocation": { "type": "NONE" },
+      "identityProof": {
+        "type": "DNS-DID",
+        "key": "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller",
+        "location": "example.tradetrust.io"
+      }
+    }
+  ],
+  "recipient": {
+    "name": "Mr Blockchain",
+    "did": "DID:SG-NRIC:S99999999A",
+    "email": "mr-blockchain@gmail.com",
+    "phone": "+65 88888888",
+    "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nric": "S0000001Z",
+    "fin": "F0000001Z",
+    "studentId": "1232"
+  },
+  "qualificationLevel": [
+    {
+      "frameworkName": "singapore/ssec-eqa",
+      "frameworkVersion": "2015",
+      "code": "51",
+      "description": "Polytechnic Diploma"
+    },
+    {
+      "frameworkName": "international/isced",
+      "frameworkVersion": "2011",
+      "code": "55",
+      "description": "(Short-cycle tertiary education) Vocational"
+    }
+  ],
+  "fieldOfStudy": [
+    {
+      "frameworkName": "singapore/ssec-fos",
+      "frameworkVersion": "2015",
+      "code": "0897",
+      "description": "Biomedical Science"
+    }
+  ],
+  "transcript": [
+    {
+      "name": "Bitcoin",
+      "grade": "A+",
+      "courseCredit": 3,
+      "courseCode": "BTC-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/BTC-01",
+      "description": "Everything and more about bitcoin!"
+    },
+    {
+      "name": "Ethereum",
+      "grade": "A+",
+      "courseCredit": "3.5",
+      "courseCode": "ETH-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/ETH-01",
+      "description": "Everything and more about ethereum!"
+    }
+  ],
+  "cumulativeScore": 3.9935,
+  "additionalData": {
+    "coCurricularActivities": [
+      {
+        "name": "Crypto-investment Club",
+        "position": "Club President",
+        "startDate": "2017-08-01T00:00:00+08:00",
+        "endDate": "2018-08-01T00:00:00+08:00",
+        "remarks": "Top trader (2018)"
+      }
+    ],
+    "npfa": "silver",
+    "images": {
+      "signature1": {
+        "name": "Mr Important",
+        "designation": "President",
+        "signature": "<-- Base64 Image -->"
+      },
+      "signature2": {
+        "name": "Mr Not-So-Important",
+        "designation": "Chairman, Blockchain Faculty",
+        "signature": "<-- Base64 Image -->"
+      }
+    }
+  },
+  "skills": [
+    {
+      "frameworkUri": "https://www.skillsfuture.sg/skills-framework",
+      "frameworkVersion": "1.0",
+      "frameworkName": "SFw",
+      "sector": "Air Transport",
+      "category": "Aircraft Operations",
+      "competencyCode": "ATP-ACO-4001-1.1",
+      "competencyDescription": "Monitor aircraft systems, performance and external environments as well as comply with Air Traffic Control (ATC) instructions and en route navigation requirements to ensure safe and optimal flight conditions",
+      "competencyLevel": "Level 4",
+      "competencyLevelDescription": "Analyse aircraft performance through close monitoring of flight decks to ensure optimal flight conditions during cruise"
+    }
+  ]
+}

--- a/schema/transcripts/2.2/example.json
+++ b/schema/transcripts/2.2/example.json
@@ -1,0 +1,132 @@
+{
+  "id": "SERIAL-2018-08-01-112",
+  "$template": {
+    "name": "CUSTOM_TEMPLATE",
+    "type": "EMBEDDED_RENDERER",
+    "url": "https://demo-renderer.opencerts.io"
+  },
+  "description": "This masters is awarded to developers who can blockchain",
+  "issuedOn": "2018-08-01T00:00:00+08:00",
+  "expiresOn": "2118-08-01T00:00:00+08:00",
+  "name": "Master of Blockchain",
+  "admissionDate": "2017-07-01T00:00:00+08:00",
+  "graduationDate": "2018-08-01T00:00:00+08:00",
+  "attainmentDate": "2018-07-25T00:00:00+08:00",
+  "issuers": [
+    {
+      "name": "Blockchain Academy",
+      "did": "DID:SG-UEN:U18274928E",
+      "url": "https://blockchainacademy.com",
+      "email": "registrar@blockchainacademy.com",
+      "documentStore": "0xd9580260be45c3c0c2fb259a82f219b513054012",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      },
+      "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000"
+    },
+    {
+      "name": "School of Crypto-economics",
+      "url": "https://ceschool.sg",
+      "documentStore": "0xA33ddAEE02369D18A21E29dD2E7A12d65eE671d2",
+      "identityProof": {
+        "type": "DNS-TXT",
+        "location": "example.com"
+      }
+    }
+  ],
+  "recipient": {
+    "name": "Mr Blockchain",
+    "did": "DID:SG-NRIC:S99999999A",
+    "email": "mr-blockchain@gmail.com",
+    "phone": "+65 88888888",
+    "additionalProp": "0x0000000000000000000000000000000000000000000000000000000000000000",
+    "nric": "S0000001Z",
+    "fin": "F0000001Z",
+    "studentId": "1232"
+  },
+  "qualificationLevel": [
+    {
+      "frameworkName": "singapore/ssec-eqa",
+      "frameworkVersion": "2015",
+      "code": "51",
+      "description": "Polytechnic Diploma"
+    },
+    {
+      "frameworkName": "international/isced",
+      "frameworkVersion": "2011",
+      "code": "55",
+      "description": "(Short-cycle tertiary education) Vocational"
+    }
+  ],
+  "fieldOfStudy": [
+    {
+      "frameworkName": "singapore/ssec-fos",
+      "frameworkVersion": "2015",
+      "code": "0897",
+      "description": "Biomedical Science"
+    }
+  ],
+  "transcript": [
+    {
+      "name": "Bitcoin",
+      "grade": "A+",
+      "courseCredit": 3,
+      "courseCode": "BTC-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/BTC-01",
+      "description": "Everything and more about bitcoin!"
+    },
+    {
+      "name": "Ethereum",
+      "grade": "A+",
+      "courseCredit": "3.5",
+      "courseCode": "ETH-01",
+      "examinationDate": "2018-08-01T00:00:00+08:00",
+      "url": "https://blockchainacademy.com/subject/ETH-01",
+      "description": "Everything and more about ethereum!"
+    }
+  ],
+  "cumulativeScore": 3.9935,
+  "additionalData": {
+    "coCurricularActivities": [
+      {
+        "name": "Crypto-investment Club",
+        "position": "Club President",
+        "startDate": "2017-08-01T00:00:00+08:00",
+        "endDate": "2018-08-01T00:00:00+08:00",
+        "remarks": "Top trader (2018)"
+      }
+    ],
+    "npfa": "silver",
+    "images": {
+      "signature1": {
+        "name": "Mr Important",
+        "designation": "President",
+        "signature": "<-- Base64 Image -->"
+      },
+      "signature2": {
+        "name": "Mr Not-So-Important",
+        "designation": "Chairman, Blockchain Faculty",
+        "signature": "<-- Base64 Image -->"
+      }
+    }
+  },
+  "skills": [
+    {
+      "frameworkUri": "https://www.skillsfuture.sg/skills-framework",
+      "frameworkVersion": "1.0",
+      "frameworkName": "SFw",
+      "sector": "Air Transport",
+      "category": "Aircraft Operations",
+      "competencyCode": "ATP-ACO-4001-1.1",
+      "competencyDescription": "Monitor aircraft systems, performance and external environments as well as comply with Air Traffic Control (ATC) instructions and en route navigation requirements to ensure safe and optimal flight conditions",
+      "competencyLevel": "Level 4",
+      "competencyLevelDescription": "Analyse aircraft performance through close monitoring of flight decks to ensure optimal flight conditions during cruise"
+    }
+  ],
+  "network": {
+    "chain": "ETHEREUM",
+    "chainId": "1"
+  }
+}

--- a/schema/transcripts/2.2/schema.json
+++ b/schema/transcripts/2.2/schema.json
@@ -1,0 +1,419 @@
+{
+  "$id": "opencerts/v2.2",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "definitions": {
+    "identityProofDns": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DNS-TXT"]
+        },
+        "location": {
+          "type": "string",
+          "description": "Url of the website referencing to document store"
+        }
+      },
+      "required": ["type", "location"]
+    },
+    "identityProofDid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DID"]
+        },
+        "key": {
+          "type": "string",
+          "description": "Public key associated"
+        }
+      },
+      "required": ["type", "key"]
+    },
+    "identityProofDnsDid": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["DNS-DID"]
+        },
+        "key": {
+          "type": "string",
+          "description": "Public key associated"
+        },
+        "location": {
+          "type": "string",
+          "description": "Url of the website referencing to document store"
+        }
+      },
+      "required": ["type", "key", "location"]
+    },
+    "identityProof": {
+      "type": "object",
+      "oneOf": [
+        { "$ref": "#/definitions/identityProofDns" },
+        { "$ref": "#/definitions/identityProofDnsDid" },
+        { "$ref": "#/definitions/identityProofDid" }
+      ]
+    },
+    "documentStore": {
+      "allOf": [
+        { "$ref": "#/definitions/issuer" },
+        {
+          "type": "object",
+          "properties": {
+            "documentStore": {
+              "type": "string"
+            }
+          },
+          "required": ["documentStore"]
+        }
+      ]
+    },
+    "certificateStore": {
+      "allOf": [
+        { "$ref": "#/definitions/issuer" },
+        {
+          "type": "object",
+          "properties": {
+            "certificateStore": {
+              "type": "string"
+            }
+          },
+          "required": ["certificateStore"]
+        }
+      ]
+    },
+    "issuer": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "did": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "url"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "identityProof": { "$ref": "#/definitions/identityProof" }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    }
+  },
+  "properties": {
+    "id": {
+      "type": "string"
+    },
+    "$template": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Template name to be use by template renderer to determine the template to use"
+        },
+        "type": {
+          "type": "string",
+          "description": "Type of renderer template",
+          "enum": ["EMBEDDED_RENDERER"]
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of a decentralised renderer to render this document"
+        }
+      },
+      "required": ["name", "type", "url"]
+    },
+    "description": {
+      "type": "string"
+    },
+    "issuedOn": {
+      "description": "The date that this certificate was issued by the issuer(s)",
+      "type": "string",
+      "format": "date-time"
+    },
+    "expiresOn": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "admissionDate": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "graduationDate": {
+      "description": "The date that this student graduated from the course",
+      "type": "string",
+      "format": "date-time"
+    },
+    "attainmentDate": {
+      "description": "The date that this qualification was awarded to the recipient",
+      "type": "string",
+      "format": "date-time"
+    },
+    "qualificationLevel": {
+      "type": "array",
+      "description": "This is an array of objects used to attach descriptors from frameworks such as Singapore's SSEC-EQA or the internationally recognised ISCED. Multiple instances are allowed to indicate either equivalents or to indicate a multi-level qualifications",
+      "items": {
+        "type": "object",
+        "required": [
+          "frameworkName",
+          "frameworkVersion",
+          "code",
+          "description"
+        ],
+        "properties": {
+          "frameworkName": {
+            "type": "string",
+            "examples": ["singapore/ssec-eqa", "international/isced"]
+          },
+          "frameworkVersion": {
+            "type": "string",
+            "examples": ["2015", "2011"]
+          },
+          "code": {
+            "type": "string",
+            "examples": ["51", "55"]
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "Polytechnic Diploma",
+              "(Short-cycle tertiary education) Vocational"
+            ]
+          }
+        }
+      }
+    },
+    "fieldOfStudy": {
+      "type": "array",
+      "description": "This is an array of objects used to attach descriptors from frameworks such as Singapore's SSEC-FOS or the internationally recognised ISCED-F. Multiple instances are allowed to indicate either equivalents or to indicate a multi-field qualification such as double degrees",
+      "items": {
+        "type": "object",
+        "required": [
+          "frameworkName",
+          "frameworkVersion",
+          "code",
+          "description"
+        ],
+        "properties": {
+          "frameworkName": {
+            "type": "string",
+            "description": "Prepend the actual framework name with the scope of the framework",
+            "examples": ["singapore/ssec-fos", "international/isced-f"]
+          },
+          "frameworkVersion": {
+            "type": "string",
+            "examples": ["2015", "2013"]
+          },
+          "code": {
+            "type": "string",
+            "examples": ["0897"]
+          },
+          "description": {
+            "type": "string",
+            "examples": ["Biomedical Science"]
+          }
+        }
+      }
+    },
+    "cumulativeScore": {
+      "type": "number"
+    },
+    "name": {
+      "type": "string"
+    },
+    "issuers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "title": "issuer",
+        "oneOf": [
+          {
+            "$ref": "#/definitions/documentStore"
+          },
+          {
+            "$ref": "#/definitions/certificateStore"
+          },
+          {
+            "allOf": [
+              { "$ref": "#/definitions/issuer" },
+              {
+                "not": {
+                  "anyOf": [
+                    {
+                      "required": ["certificateStore"]
+                    },
+                    {
+                      "required": ["documentStore"]
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ],
+        "additionalProperties": true
+      },
+      "minItems": 1
+    },
+    "recipient": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "did": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        },
+        "email": {
+          "type": "string"
+        },
+        "phone": {
+          "type": "string"
+        },
+        "nric": {
+          "type": "string"
+        },
+        "fin": {
+          "type": "string"
+        },
+        "studentId": {
+          "type": "string"
+        }
+      },
+      "required": ["name"],
+      "additionalProperties": true
+    },
+    "transcript": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "score": {
+            "type": ["number", "string"]
+          },
+          "grade": {
+            "type": ["number", "string"]
+          },
+          "courseCredit": {
+            "type": ["number", "string"]
+          },
+          "courseCode": {
+            "type": "string"
+          },
+          "examinationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "languageMedium": {
+            "description": "Language that the course was undertaken in",
+            "type": "string"
+          }
+        },
+        "required": ["name"]
+      }
+    },
+    "additionalData": {
+      "type": "object"
+    },
+    "skills": {
+      "description": "Information about skills that the recipient learnt",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "frameworkUri": {
+            "description": "URI where to find the details about the framework",
+            "type": "string",
+            "format": "uri",
+            "examples": ["https://www.skillsfuture.sg/skills-framework"]
+          },
+          "frameworkName": {
+            "description": "Framework name",
+            "type": "string",
+            "examples": ["SFw"]
+          },
+          "frameworkVersion": {
+            "description": "Framework version",
+            "type": "string",
+            "examples": ["1.0"]
+          },
+          "sector": {
+            "description": "The industry/sector for which this framework is meant for",
+            "type": "string",
+            "examples": ["Air Transport"]
+          },
+          "category": {
+            "description": "Skills and competency category. (Technical Skills Competency (TSC) or Critical Core Skills (CCS)",
+            "type": "string",
+            "examples": ["Aircraft Operations"]
+          },
+          "competencyCode": {
+            "description": "Skills and competency code from Skills Framework",
+            "type": "string",
+            "examples": ["ATP-ACO-4001-1.1"]
+          },
+          "competencyDescription": {
+            "description": "Detailed description of the skill or competency",
+            "type": "string",
+            "examples": [
+              "Monitor aircraft systems, performance and external environments as well as comply with Air Traffic Control (ATC) instructions and en route navigation requirements to ensure safe and optimal flight conditions"
+            ]
+          },
+          "competencyLevel": {
+            "description": "Level of competency / skills: TSC Pro Level (numeric from 1 onward), GSC Pro Level (Critical Core Skills - basic, intermediate, advanced)",
+            "type": "string",
+            "examples": ["Level 4"]
+          },
+          "competencyLevelDescription": {
+            "description": "Narrative information for this competency level",
+            "type": "string",
+            "examples": [
+              "Analyse aircraft performance through close monitoring of flight decks to ensure optimal flight conditions during cruise"
+            ]
+          }
+        },
+        "required": ["frameworkUri", "frameworkName", "frameworkVersion"]
+      }
+    },
+    "network": {
+      "type": "object",
+      "properties": {
+        "chain": {
+          "type": "string",
+          "description": "Which blockchain being used"
+        },
+        "chainId": {
+          "type": "string",
+          "description": "Chain ID of the network used"
+        }
+      },
+      "required": ["chain", "chainId"],
+      "additionalProperties": true
+    }
+  },
+  "required": ["id", "name", "issuedOn", "issuers", "recipient"],
+  "additionalProperties": false
+}

--- a/schema/transcripts/2.2/schema.test.js
+++ b/schema/transcripts/2.2/schema.test.js
@@ -1,0 +1,980 @@
+/* eslint-disable */
+const schema = require("./schema.json");
+let {
+  issueDocument,
+  addSchema,
+  validateSchema
+} = require("@govtechsg/open-attestation");
+
+describe("schema/v2.2", () => {
+  beforeEach(() => {
+    addSchema(schema);
+  });
+
+  afterEach(() => {
+    delete require.cache[require.resolve("@govtechsg/open-attestation")];
+    let {
+      issueDocument,
+      addSchema,
+      validateSchema
+    } = require("@govtechsg/open-attestation");
+  });
+
+  it("is not valid with missing data", () => {
+    const data = {};
+    const signing = () => issueDocument(data, schema);
+    expect(signing).toThrow("Invalid document");
+  });
+
+  it("is not valid with additional data", () => {
+    const data = {
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      },
+      invalidKey: "value"
+    };
+    const signing = () => issueDocument(data, schema);
+    expect(signing).toThrow("Invalid document");
+  });
+
+  it("is not valid with empty issuer array (issue with 1.3)", () => {
+    const data = {
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [],
+      recipient: {
+        name: "Recipient Name"
+      },
+      invalidKey: "value"
+    };
+    const signing = () => issueDocument(data, schema);
+    expect(signing).toThrow("Invalid document");
+  });
+
+  it("is valid with minimum data", () => {
+    const data = {
+      id: "Example-minimal-2018-001",
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      }
+    };
+
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  describe("schema 2.0 specific additions", () => {
+    it("should work with new $template format", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: "GOVTECH_DEMO",
+          type: "EMBEDDED_RENDERER",
+          url: "https://demo-renderer.opencerts.io"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signedDocument = issueDocument(data, schema);
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+
+    it("should fail with empty $template format", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {},
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with invalid $template name field", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: 5,
+          type: "EMBEDDED_RENDERER",
+          url: "https://demo-renderer.opencerts.io"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with invalid $template type field", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: "GOVTECH_DEMO",
+          type: "IFRAME_RENDERER",
+          url: "https://demo-renderer.opencerts.io"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with invalid $template url field", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: "GOVTECH_DEMO",
+          type: "EMBEDDED_RENDERER",
+          url: 5
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with $template name missing", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          type: "EMBDEDDED_RENDERER",
+          url: "https://demo-renderer.opencerts.io"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with $template type missing", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: "GOVTECH_DEMO",
+          url: "https://demo-renderer.opencerts.io"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail with $template url missing", () => {
+      const data = {
+        id: "new $template",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        },
+        $template: {
+          name: "GOVTECH_DEMO",
+          type: "EMBEDDED_RENDERER"
+        },
+        qualificationLevel: [
+          {
+            frameworkName: "singapore/ssec-eqa",
+            frameworkVersion: "2015",
+            code: "51",
+            description: "Polytechnic Diploma"
+          }
+        ],
+        fieldOfStudy: [
+          {
+            frameworkName: "singapore/ssec-fos",
+            frameworkVersion: "2015",
+            code: "0897",
+            description: "Biomedical Science"
+          }
+        ]
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail when identity type is missing", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail when identity location is missing", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+
+    it("should fail when identity type is not dns-txt", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "ABC",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+
+      const signing = () => issueDocument(data, schema);
+      expect(signing).toThrow("Invalid document");
+    });
+  });
+
+  it("is valid with additional properties in issuer", () => {
+    const data = {
+      id: "Example-minimal-2018-001",
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          additionalProp: true,
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      }
+    };
+
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  it("is valid with additional properties in recipient", () => {
+    const data = {
+      id: "Example-minimal-2018-001",
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name",
+        additionalProp: true
+      }
+    };
+
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  it("is valid with standard data", () => {
+    const data = {
+      id: "Example-standard-2018-002",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      expiresOn: "2118-08-01T00:00:00+08:00",
+      name: "Master of Blockchain",
+      description: "some description",
+      issuers: [
+        {
+          name: "Blockchain Academy",
+          did: "DID:SG-UEN:U18274928E",
+          url: "https://blockchainacademy.com",
+          email: "registrar@blockchainacademy.com",
+          documentStore: "0xd9580260be45c3c0c2fb259a82f219b513054012",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Mr Blockchain",
+        did: "DID:SG-NRIC:S99999999A",
+        email: "mr-blockchain@gmail.com",
+        phone: "+65 88888888"
+      },
+      transcript: [
+        {
+          name: "Bitcoin",
+          grade: "A+",
+          courseCredit: 3,
+          courseCode: "BTC-01",
+          url: "https://blockchainacademy.com/subject/BTC-01",
+          description: "Everything and more about bitcoin!"
+        },
+        {
+          name: "Ethereum",
+          grade: "A+",
+          courseCredit: "3.5",
+          courseCode: "ETH-01",
+          url: "https://blockchainacademy.com/subject/ETH-01",
+          description: "Everything and more about ethereum!"
+        }
+      ]
+    };
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  it("is valid with extra metadata data", () => {
+    const data = {
+      id: "Example-extrameta-2018-003",
+      name: "Certificate Name",
+      description: "some description",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      },
+      transcript: [
+        {
+          name: "Bitcoin",
+          "random-key": "Is Valid"
+        }
+      ],
+      additionalData: {
+        array: [
+          {
+            key: "value"
+          },
+          {
+            key: "value2"
+          }
+        ],
+        number: 2,
+        string: "hello",
+        object: {
+          hello: "world"
+        }
+      }
+    };
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  it("validates the example document", () => {
+    const data = require("./example.json");
+    const signedDocument = issueDocument(data, schema);
+    const valid = validateSchema(signedDocument);
+    expect(valid).toBeTruthy();
+  });
+
+  describe("documentStore and certificateStore", () => {
+    it(
+      "should fail when there is both documentStore and certificateStore",
+      () => {
+        const data = {
+          id: "Example-minimal-2018-001",
+          name: "Certificate Name",
+          issuedOn: "2018-08-01T00:00:00+08:00",
+          issuers: [
+            {
+              name: "Issuer Name",
+              documentStore: "0x0000000000000000000000000000000000000000",
+              certificateStore: "0x0000000000000000000000000000000000000000",
+              identityProof: {
+                type: "DNS-TXT",
+                location: "example.com"
+              }
+            }
+          ],
+          recipient: {
+            name: "Recipient Name"
+          }
+        };
+        const signing = () => issueDocument(data, schema);
+        expect(signing).toThrow("Invalid document");
+      }
+    );
+    it("is valid when there is only documentStore", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            documentStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+      const signedDocument = issueDocument(data, schema);
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+    it("is valid when there is only certificateStore", () => {
+      const data = {
+        id: "Example-minimal-2018-001",
+        name: "Certificate Name",
+        issuedOn: "2018-08-01T00:00:00+08:00",
+        issuers: [
+          {
+            name: "Issuer Name",
+            certificateStore: "0x0000000000000000000000000000000000000000",
+            identityProof: {
+              type: "DNS-TXT",
+              location: "example.com"
+            }
+          }
+        ],
+        recipient: {
+          name: "Recipient Name"
+        }
+      };
+      const signedDocument = issueDocument(data, schema);
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+  });
+
+  describe("did", () => {
+    it("should be valid with document issued using did signing", () => {
+      const data = require("./example-did-document.json");
+      const signedDocument = issueDocument(data, schema);
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+    it("should be valid with document issued using dns-did signing", () => {
+      const data = require("./example-dns-did-document.json");
+      const signedDocument = issueDocument(data, schema);
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+    it("should be invalid with dns-did signing without location", () => {
+      const data = require("./example-dns-did-document.json");
+
+      data.issuers = [
+        {
+          id: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+          name: "DEMO STORE",
+          revocation: { type: "NONE" },
+          identityProof: {
+            type: "DNS-DID",
+            key:
+              "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89#controller"
+          }
+        }
+      ];
+
+      expect(() => issueDocument(data, schema)).toThrow("Invalid document");
+    });
+    it("should be invalid with dns-did signing without key", () => {
+      const data = require("./example-dns-did-document.json");
+      data.issuers = [
+        {
+          id: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+          name: "DEMO STORE",
+          revocation: { type: "NONE" },
+          identityProof: {
+            type: "DNS-DID",
+            location: "example.tradetrust.io"
+          }
+        }
+      ];
+      expect(() => issueDocument(data, schema)).toThrow("Invalid document");
+    });
+    it("should be invalid with did signing without key", () => {
+      const data = require("./example-dns-did-document.json");
+      data.issuers = [
+        {
+          id: "did:ethr:0xE712878f6E8d5d4F9e87E10DA604F9cB564C9a89",
+          name: "DEMO STORE",
+          revocation: { type: "NONE" },
+          identityProof: {
+            type: "DID"
+          }
+        }
+      ];
+      expect(() => issueDocument(data, schema)).toThrow("Invalid document");
+    });
+  });
+
+  describe("skills", () => {
+    const data = {
+      id: "Example-minimal-2018-001",
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      }
+    };
+
+    it("is not valid when frameworkUri is missing", () => {
+      expect(() =>
+        issueDocument(
+          {
+            ...data,
+            skills: [
+              {
+                frameworkName: "frameworkName",
+                frameworkVersion: "frameworkVersion"
+              }
+            ]
+          },
+          schema
+        )
+      ).toThrow("Invalid document");
+    });
+
+    it("is not valid when frameworkName is missing", () => {
+      expect(() =>
+        issueDocument(
+          {
+            ...data,
+            skills: [
+              {
+                frameworkUri: "https://some.exanple.com",
+                frameworkVersion: "frameworkVersion"
+              }
+            ]
+          },
+          schema
+        )
+      ).toThrow("Invalid document");
+    });
+
+    it("is not valid when frameworkVersion is missing", () => {
+      expect(() =>
+        issueDocument(
+          {
+            ...data,
+            skills: [
+              {
+                frameworkUri: "https://some.exanple.com",
+                frameworkName: "frameworkName"
+              }
+            ]
+          },
+          schema
+        )
+      ).toThrow("Invalid document");
+    });
+
+    it("is not valid when frameworkUri is not a uri", () => {
+      expect(() =>
+        issueDocument(
+          {
+            ...data,
+            skills: [
+              {
+                frameworkUri: "frameworkUri",
+                frameworkVersion: "frameworkVersion",
+                frameworkName: "frameworkName"
+              }
+            ]
+          },
+          schema
+        )
+      ).toThrow("Invalid document");
+    });
+
+    it("is valid", () => {
+      const signedDocument = issueDocument(
+        {
+          ...data,
+          skills: [
+            {
+              frameworkUri: "https://some.exanple.com",
+              frameworkVersion: "frameworkVersion",
+              frameworkName: "frameworkName"
+            }
+          ]
+        },
+        schema
+      );
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+  });
+
+  describe("network", () => {
+    const data = {
+      id: "Example-minimal-2018-001",
+      name: "Certificate Name",
+      issuedOn: "2018-08-01T00:00:00+08:00",
+      issuers: [
+        {
+          name: "Issuer Name",
+          documentStore: "0x0000000000000000000000000000000000000000",
+          identityProof: {
+            type: "DNS-TXT",
+            location: "example.com"
+          }
+        }
+      ],
+      recipient: {
+        name: "Recipient Name"
+      }
+    };
+
+    it("is not valid when chain is missing", () => {
+      expect(() =>
+          issueDocument(
+              {
+                ...data,
+                network: {
+                    chainId: "1"
+                  }
+              },
+              schema
+          )
+      ).toThrow("Invalid document");
+    });
+
+    it("is not valid when chainId is missing", () => {
+      expect(() =>
+          issueDocument(
+              {
+                ...data,
+                network: {
+                  chain: "Ethereum"
+                }
+              },
+              schema
+          )
+      ).toThrow("Invalid document");
+    });
+
+    it("is valid", () => {
+      const signedDocument = issueDocument(
+          {
+            ...data,
+            network: {
+              chain: "Ethereum",
+              chainId: "1"
+            }
+          },
+          schema
+      );
+      const valid = validateSchema(signedDocument);
+      expect(valid).toBeTruthy();
+    });
+  });
+});

--- a/scripts/publishSchema.sh
+++ b/scripts/publishSchema.sh
@@ -24,6 +24,7 @@ copy "transcripts" "1.4"
 copy "transcripts" "1.5"
 copy "transcripts" "2.0"
 copy "transcripts" "2.1"
+copy "transcripts" "2.2"
 # copy testimonials
 copy "testimonials" "1.0"
 # copy certificate of awards

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,8 @@ const schemas = {
   1.4: require("../schema/transcripts/1.4/schema.json"),
   1.5: require("../schema/transcripts/1.5/schema.json"),
   2.0: require("../schema/transcripts/2.0/schema.json"),
+  2.1: require("../schema/transcripts/2.1/schema.json"),
+  2.2: require("../schema/transcripts/2.2/schema.json"),
 };
 /* eslint-enable global-require */
 


### PR DESCRIPTION
## Proposed changes

This pull request introduces support for transcript schema version 2.2, including updates to changelogs, examples, and build scripts. The main focus is on adding a new optional `network` field to support DNS-TXT Blockchain issued certificates, and providing updated example documents for this schema version.

Schema and example updates:

* Added a new optional `network` field (with `chain` and `chainId` properties) to the transcript schema for compatibility with DNS-TXT Blockchain issued certificates, as documented in the changelog. [[1]](diffhunk://#diff-7d6e87a18f2ef28fa5870083685cf61e740fd22ed9fa5b305cd0d04bee3c5ffaR1-R6) [[2]](diffhunk://#diff-af3fe2cb70216d4f4be3395b7dcb1fb06efe6653bf5eeedaa483f637c6180627R1-R132)
* Added comprehensive example documents for schema version 2.2, including `example.json`, `example-did-document.json`, and `example-dns-did-document.json`, demonstrating usage of the new schema features and various issuer/identityProof configurations. [[1]](diffhunk://#diff-af3fe2cb70216d4f4be3395b7dcb1fb06efe6653bf5eeedaa483f637c6180627R1-R132) [[2]](diffhunk://#diff-8ac878318be03f9e0ce3157183e3f38c4c309daa26e8b398907ac3471ad9f196R1-R137) [[3]](diffhunk://#diff-36cee96f7218c3b0d8c3d28585f013682a2dff2d05a5d7b0dbc818ed889a15efR1-R138)

Build and integration updates:

* Updated the schema publishing script (`publishSchema.sh`) to include copying the new `2.2` transcripts schema.
* Registered the new `2.2` schema in the main schema index, making it available for use in the application.

#### Link to Jira Ticket

https://accredify.atlassian.net/browse/PN-3431

## Checklist

- [x] The pull request and ticket contain a clear and concise description of the change
- [x] The pull request is labeled with one of the following: `New Feature`, `Bugfix`, `Refactoring`, `DevOps`, `Chore`
- [x] I have reviewed the changes myself
- [x] I have added/updated tests that prove my fix is effective or that my feature works