### PR TITLE
[DSO-3251] Exempt internal workflows from Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,7 @@ updates:
       timezone: Asia/Singapore
     open-pull-requests-limit: 10
     target-branch: "master"
+    cooldown:
+      default-days: 5
+      exclude:
+        - "Accredifysg/Accredify-Github-Workflows*"


### PR DESCRIPTION
## Proposed changes

Adds a `cooldown.exclude` entry to the `github-actions` Dependabot update block so first-party internal workflow updates (`Accredifysg/Accredify-Github-Workflows*`) are not delayed by the fleet-wide Dependabot cooldown, since they are implicitly trusted.

No `terraform` block or `*.tf` files exist in this repo, so no terraform changes were made. The `npm` block's cooldown was left untouched (it has none).

#### Link to Jira Ticket

https://accredify.atlassian.net/browse/DSO-3251 <!-- Replace with actual JIRA ticket URL -->

### Updated
- `.github/dependabot.yml` — added `cooldown: {default-days: 5, exclude: ["Accredifysg/Accredify-Github-Workflows*"]}` to the `github-actions` update block

## Checklist

- [x] The pull request and ticket contain a clear and concise description of the change
- [ ] The pull request is labeled with one of the following: `New Feature`, `Bugfix`, `Refactoring`, `DevOps`, `Chore`
- [x] I have reviewed the changes myself
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have added migration script to ensure existing data won't cause errors - in case of enum change, non-nullable columns change, etc. (if appropriate)
- [ ] I have added/updated necessary documentation (if appropriate)
